### PR TITLE
hotfix, updated sync logic, resources bundled for export

### DIFF
--- a/AzureAITranslatorService/AzureAITranslatorService.csproj
+++ b/AzureAITranslatorService/AzureAITranslatorService.csproj
@@ -1,103 +1,100 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{DF9EFAA8-68D4-42F8-88F4-2EEB4CE123B2}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AzureAITranslatorService</RootNamespace>
-    <AssemblyName>AzureAITranslatorService</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <UseCodebase>true</UseCodebase>
-    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
-    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
-    <StartAction>Program</StartAction>
-    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
-    <StartArguments>/rootsuffix Exp</StartArguments>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Constants\Constants.cs" />
-    <Compile Include="Helpers\ExcelHelper.cs" />
-    <Compile Include="Helpers\ResxFileReader.cs" />
-    <Compile Include="Models\ResxEntry.cs" />
-    <Compile Include="Models\TranslationEntry.cs" />
-    <Compile Include="MyCommand.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AzureAITranslatorServicePackage.cs" />
-    <Compile Include="Services\ResxSynchronizer.cs" />
-    <Compile Include="SynchronizeLanguageFilesCommand.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="EPPlus">
-      <Version>7.2.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.3184" />
-    <PackageReference Include="System.Xml.Linq">
-      <Version>3.5.21022.801</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <VSCTCompile Include="AzureAITranslatorServicePackage.vsct">
-      <ResourceName>Menus.ctmenu</ResourceName>
-    </VSCTCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Resources\MyCommand.png" />
-    <Content Include="Resources\ResxSchema.txt" />
-    <Content Include="Resources\SynchronizeLanguageFilesCommand.png" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+	<PropertyGroup>
+		<MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+		<VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+	</PropertyGroup>
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<ProjectGuid>{DF9EFAA8-68D4-42F8-88F4-2EEB4CE123B2}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>AzureAITranslatorService</RootNamespace>
+		<AssemblyName>AzureAITranslatorService</AssemblyName>
+		<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+		<GeneratePkgDefFile>true</GeneratePkgDefFile>
+		<UseCodebase>true</UseCodebase>
+		<IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+		<IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+		<IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+		<CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+		<CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+		<StartAction>Program</StartAction>
+		<StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+		<StartArguments>/rootsuffix Exp</StartArguments>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Compile Include="Constants\Constants.cs" />
+		<Compile Include="Helpers\ExcelHelper.cs" />
+		<Compile Include="Helpers\ResxFileReader.cs" />
+		<Compile Include="Models\ResxEntry.cs" />
+		<Compile Include="Models\TranslationEntry.cs" />
+		<Compile Include="MyCommand.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="AzureAITranslatorServicePackage.cs" />
+		<Compile Include="Services\ResxSynchronizer.cs" />
+		<Compile Include="SynchronizeLanguageFilesCommand.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="source.extension.vsixmanifest">
+			<SubType>Designer</SubType>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Design" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Windows.Forms" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="EPPlus">
+			<Version>7.2.0</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.3184" />
+		<PackageReference Include="System.Xml.Linq">
+			<Version>3.5.21022.801</Version>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<VSCTCompile Include="AzureAITranslatorServicePackage.vsct">
+			<ResourceName>Menus.ctmenu</ResourceName>
+		</VSCTCompile>
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="Resources\MyCommand.png" />
+		<Content Include="Resources\ResxSchema.txt">
+			<IncludeInVSIX>true</IncludeInVSIX>
+		</Content>
+		<Content Include="Resources\SynchronizeLanguageFilesCommand.png" />
+	</ItemGroup>
+	<Target Name="CopyContentFiles" AfterTargets="Build">
+		<Copy SourceFiles="@(Content)" DestinationFolder="$(OutputPath)%(RelativeDir)" />
+	</Target>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/AzureAITranslatorService/Constants/Constants.cs
+++ b/AzureAITranslatorService/Constants/Constants.cs
@@ -1,19 +1,49 @@
-﻿using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio;
-using System;
-using System.Diagnostics;
+﻿using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 public static class Constants
 {
-    public static readonly string ResxSchemaPath = GetFilePath("AzureAITranslatorService", "Resources", "ResxSchema.txt");
+    //A note on exporting files with vsix:
+    //In the csproj file, the content resource must have the
+    //<IncludeInVSIX>true</IncludeInVSIX> tag. 
+    public static readonly string ResxSchemaPath = GetFilePath("Resources", "ResxSchema.txt");
 
     private static string GetFilePath(params string[] paths)
     {
-        throw new NotImplementedException();
-        //TODO: fix this shit
+        string assemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string debugResourcesPath = Path.Combine(assemblyLocation, "Resources", "ResxSchema.txt");
+
+        if (File.Exists(debugResourcesPath))
+        {
+            return debugResourcesPath;
+        }
+
+        string filePath = Path.Combine(assemblyLocation, Path.Combine(paths));
+        if (File.Exists(filePath))
+        {
+            return filePath;
+        }
+
+        string parentDirectory = Directory.GetParent(assemblyLocation).FullName;
+        string parentFilePath = Path.Combine(parentDirectory, Path.Combine(paths));
+        if (File.Exists(parentFilePath))
+        {
+            return parentFilePath;
+        }
+
+        string devDirectory = Directory.GetParent(assemblyLocation).Parent.Parent.Parent.FullName;
+        string devFilePath = Path.Combine(devDirectory, Path.Combine(paths));
+        if (File.Exists(devFilePath))
+        {
+            return devFilePath;
+        }
+
+        System.Diagnostics.Debug.WriteLine($"File not found in: {debugResourcesPath}");
+        System.Diagnostics.Debug.WriteLine($"File not found in: {filePath}");
+        System.Diagnostics.Debug.WriteLine($"File not found in: {parentFilePath}");
+        System.Diagnostics.Debug.WriteLine($"File not found in: {devFilePath}");
+
+        throw new FileNotFoundException($"Schema file not found in any checked locations: {debugResourcesPath}, {filePath}, {parentFilePath}, {devFilePath}");
     }
 }

--- a/AzureAITranslatorService/Services/ResxSynchronizer.cs
+++ b/AzureAITranslatorService/Services/ResxSynchronizer.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Resources;
 using System.Xml.Linq;
 
 public static class ResxSynchronizer
@@ -37,22 +34,21 @@ public static class ResxSynchronizer
             var sourceEntries = ReadResxFile(sourceResxPath);
             var targetEntries = ReadResxFile(targetResxPath);
 
-            var allKeys = new HashSet<string>(sourceEntries.Keys.Concat(targetEntries.Keys));
+            var updatedTargetEntries = new OrderedDictionary();
 
-            var updatedTargetEntries = new Dictionary<string, (string Value, string Comment)>();
-            foreach (var key in allKeys)
+            // Add existing target entries first
+            foreach (DictionaryEntry entry in targetEntries)
             {
-                if (targetEntries.ContainsKey(key))
+                updatedTargetEntries[entry.Key] = entry.Value;
+            }
+
+            // Add new entries from source
+            foreach (DictionaryEntry entry in sourceEntries)
+            {
+                if (!targetEntries.Contains(entry.Key))
                 {
-                    updatedTargetEntries[key] = targetEntries[key];
-                }
-                else if (sourceEntries.ContainsKey(key))
-                {
-                    updatedTargetEntries[key] = sourceEntries[key];
-                }
-                else
-                {
-                    updatedTargetEntries[key] = (string.Empty, string.Empty); // Add empty value and comment for missing keys
+                    var valueTuple = ((string Value, string Comment))entry.Value;
+                    updatedTargetEntries[entry.Key] = (valueTuple.Value, "New");
                 }
             }
 
@@ -64,9 +60,9 @@ public static class ResxSynchronizer
         }
     }
 
-    private static Dictionary<string, (string Value, string Comment)> ReadResxFile(string resxPath)
+    private static OrderedDictionary ReadResxFile(string resxPath)
     {
-        var entries = new Dictionary<string, (string Value, string Comment)>();
+        var entries = new OrderedDictionary();
         var xdoc = XDocument.Load(resxPath);
 
         foreach (var data in xdoc.Root.Elements("data"))
@@ -83,7 +79,7 @@ public static class ResxSynchronizer
         return entries;
     }
 
-    private static void WriteResxFile(string resxPath, Dictionary<string, (string Value, string Comment)> entries)
+    private static void WriteResxFile(string resxPath, OrderedDictionary entries)
     {
         var doc = new XDocument(
             new XElement("root",
@@ -102,17 +98,17 @@ public static class ResxSynchronizer
                     new XElement("value", "System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"))
             )
         );
-
-        foreach (var entry in entries)
+        
+        foreach (DictionaryEntry entry in entries)
         {
             var dataElement = new XElement("data",
-                new XAttribute("name", entry.Key),
+                new XAttribute("name", (string)entry.Key),
                 new XAttribute(XNamespace.Xml + "space", "preserve"),
-                new XElement("value", entry.Value.Value));
+                new XElement("value", ((ValueTuple<string, string>)entry.Value).Item1));
 
-            if (!string.IsNullOrEmpty(entry.Value.Comment))
+            if (!string.IsNullOrEmpty(((ValueTuple<string, string>)entry.Value).Item2))
             {
-                dataElement.Add(new XElement("comment", entry.Value.Comment));
+                dataElement.Add(new XElement("comment", ((ValueTuple<string, string>)entry.Value).Item2));
             }
 
             doc.Root.Add(dataElement);

--- a/VSIXProject/source.extension.vsixmanifest
+++ b/VSIXProject/source.extension.vsixmanifest
@@ -18,5 +18,6 @@
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.Content.Files" Path="Resources\ResxSchema.txt" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Constants file was unable to locate the ResxSchema.txt file. I had forgotten to include "<IncludeInVSIX>true</IncludeInVSIX>" in the csproj file as well as adding it to the vsix manifest. 

Additionally improved Regex pattern to work with any (and all!) AppResources-[xx].resx files in Source(user's right-click target) file directory. 

Finally, corrected logic surrounding when to add key to sync-targetFile.

`// Add new entries from source
foreach (DictionaryEntry entry in sourceEntries)
{
    if (!targetEntries.Contains(entry.Key))
    {
        var valueTuple = ((string Value, string Comment))entry.Value;
        updatedTargetEntries[entry.Key] = (valueTuple.Value, "New");
    }
}`